### PR TITLE
Hide Data.List.List from Prelude import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/library/Ptr/Prelude.hs
+++ b/library/Ptr/Prelude.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Ptr.Prelude
   ( module Exports,
   )
@@ -34,7 +36,11 @@ import Data.Functor.Contravariant.Divisible as Exports
 import Data.IORef as Exports
 import Data.Int as Exports
 import Data.Ix as Exports
+#if MIN_VERSION_base(4,20,0)
+import Data.List as Exports hiding (List, all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons)
+#else
 import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons)
+#endif
 import Data.List.NonEmpty as Exports (NonEmpty (..))
 import Data.Maybe as Exports
 import Data.Monoid as Exports hiding (Alt, (<>))


### PR DESCRIPTION
This PR hides the `Data.List.List` identifier from the Data.List import in Ptr/Prelude.hs.

Since the identifier will arrive with [base-4.20.0.0](https://gitlab.haskell.org/ghc/ghc/-/blob/2776920e642544477a38d0ed9205d4f0b48a782e/libraries/base/changelog.md#42000-tba), this hiding is guarded behind a CPP conditional.